### PR TITLE
PHP

### DIFF
--- a/php.md
+++ b/php.md
@@ -1,0 +1,25 @@
+PHP
+===
+
+1.  We adhere to all [PHP Framework Interop Group](http://www.php-fig.org)
+    standards, particularly [PSR-2](http://www.php-fig.org/psr/psr-2/) as a
+    coding style guide. It's recommended to use a tool such as
+    [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) or
+    [PHP Coding Standards Fixer](https://github.com/fabpot/PHP-CS-Fixer) to
+    easily detect — and even fix — violations to the standard.
+2.  Dependency management should be done with [Composer](https://getcomposer.org).
+3.  Code documentation should be done with [phpDocumentor](http://www.phpdoc.org).
+4.  Testing should be done with [Codeception](http://codeception.com) when a
+    combination of acceptance, functional, API, and unit testing is necessary
+    (such as for an app). Use [phpUnit](http://phpunit.de) when only unit
+    testing is necessary.
+5.  Task running should be done with [Grunt](http://gruntjs.com), which is
+    becoming [increasingly](https://chrsm.org/2013/04/25/using-grunt-for-php/)
+    [popular](http://mariehogebrandt.se/articles/using-grunt-php-quality-assurance-tools)
+    among PHP projects as an alternative to [Phing](http://www.phing.info).
+6.  Code quality and analysis tools should be used if possible, such as:
+    *   [PHPLOC](https://github.com/sebastianbergmann/phploc)
+    *   [PHPCPD](https://github.com/sebastianbergmann/phpcpd)
+    *   [PHPCDC](https://github.com/sebastianbergmann/phpdcd)
+    *   [SensioLabs Security Checker](https://github.com/sensiolabs/security-checker)
+    *   [PHP Mess Detector](http://phpmd.org)


### PR DESCRIPTION
Here's an initial draft of PHP conventions based on discussion in [the GitHub Issue](https://github.com/MonkDev/monk-conventions/issues/4).

I purposely left out project-specific conventions that only apply to Monk CMS, Cobblestone, etc. Those can be noted in the project's README or wiki. I also left out conventions like code/comment line length that will be part of the general conventions.

I'll also note this in the README, but all conventions are "SHOULD BE", not "MUST BE". That is, they should be followed unless it's impractical due to it being a legacy code base or something. For example, as it's been noted in the discussion, Monk CMS can't follow PSR-2 exactly without some major changes. That's fine — follow it as closely as possible. New projects like Monk ID PHP, however, should follow it exactly since it's not too difficult getting it in line.

@shanebonham @mcordell @rickyatmonk @lefthand @etdebruin Your feedback is welcome! Please :thumbsup: when you're on board.
